### PR TITLE
fix for basic-reentrancy semgrep rule

### DIFF
--- a/solidity/basic-reentrancy.yaml
+++ b/solidity/basic-reentrancy.yaml
@@ -12,9 +12,9 @@ rules:
     patterns:
     - pattern-either:
             - pattern-inside: |
-                function $F(..., $X, ...) external { ... }
+                function $F(..., $TYPE $X, ...) external { ... }
             - pattern-inside: |
-                function $F(..., $X, ...) public { ... }
+                function $F(..., $TYPE $X, ...) public { ... }
     - pattern-not-inside: |
         function $F(..., $X, ...) onlyOwner { ... }
     - pattern: $X.$M(...)


### PR DESCRIPTION
The analysis of the basic-reentrancy.sol file now detects the following reentrancies:
 
line 267┆ _newPool.receiveHop(amt, msg.sender, payable(address(this)));
and line 340┆ _shitcoin.balanceOf(address(this)),

